### PR TITLE
#10 Create aop for specific authorization on end point

### DIFF
--- a/jwt/src/main/java/org/callimard/makemeacube/jwt/JwtAccount.java
+++ b/jwt/src/main/java/org/callimard/makemeacube/jwt/JwtAccount.java
@@ -19,6 +19,7 @@ public class JwtAccount {
 
     public static final String CLAIM_ACCOUNT = "account";
 
+    public static final String CLAIM_USER_ID = "id";
     public static final String CLAIM_MAIL = "mail";
     public static final String CLAIM_PSEUDO = "pseudo";
     public static final String CLAIM_FIRST_NAME = "firstName";
@@ -26,6 +27,7 @@ public class JwtAccount {
 
     // Variables.
 
+    private Integer id;
     private String mail;
     private String pseudo;
     private String firstName;
@@ -42,13 +44,13 @@ public class JwtAccount {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof JwtAccount that)) return false;
-        return Objects.equal(mail, that.mail) && Objects.equal(pseudo, that.pseudo) &&
+        return Objects.equal(id, that.id) && Objects.equal(mail, that.mail) && Objects.equal(pseudo, that.pseudo) &&
                 Objects.equal(firstName, that.firstName) && Objects.equal(lastName, that.lastName) &&
                 Objects.equal(privileges, that.privileges);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(mail, pseudo, firstName, lastName, privileges);
+        return Objects.hashCode(id, mail, pseudo, firstName, lastName, privileges);
     }
 }

--- a/jwt/src/main/java/org/callimard/makemeacube/jwt/JwtFactory.java
+++ b/jwt/src/main/java/org/callimard/makemeacube/jwt/JwtFactory.java
@@ -42,6 +42,6 @@ public class JwtFactory {
     }
 
     private JwtAccount generateJwtAccount(User user) {
-        return new JwtAccount(user.getMail(), user.getPseudo(), user.getFirstName(), user.getLastName(), Lists.newArrayList());
+        return new JwtAccount(user.getId(), user.getMail(), user.getPseudo(), user.getFirstName(), user.getLastName(), Lists.newArrayList());
     }
 }

--- a/jwt/src/main/java/org/callimard/makemeacube/jwt/aop/JwtAuthenticationAspect.java
+++ b/jwt/src/main/java/org/callimard/makemeacube/jwt/aop/JwtAuthenticationAspect.java
@@ -1,0 +1,23 @@
+package org.callimard.makemeacube.jwt.aop;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.callimard.makemeacube.jwt.JwtAccount;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+@Order(0)
+public class JwtAuthenticationAspect {
+
+    // Methods.
+
+    @Before("@annotation(org.callimard.makemeacube.jwt.aop.RequiresJwtAuthentication)")
+    public void requiresJwtAuthentication() {
+        if (!(SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof JwtAccount)) {
+            throw new JwtAuthenticationRequiredException();
+        }
+    }
+}

--- a/jwt/src/main/java/org/callimard/makemeacube/jwt/aop/JwtAuthenticationRequiredException.java
+++ b/jwt/src/main/java/org/callimard/makemeacube/jwt/aop/JwtAuthenticationRequiredException.java
@@ -1,0 +1,14 @@
+package org.callimard.makemeacube.jwt.aop;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class JwtAuthenticationRequiredException extends RuntimeException {
+
+    // Constructors.
+
+    public JwtAuthenticationRequiredException() {
+        super("Jwt authentication required");
+    }
+}

--- a/jwt/src/main/java/org/callimard/makemeacube/jwt/aop/RequiresJwtAuthentication.java
+++ b/jwt/src/main/java/org/callimard/makemeacube/jwt/aop/RequiresJwtAuthentication.java
@@ -1,0 +1,11 @@
+package org.callimard.makemeacube.jwt.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiresJwtAuthentication {
+}

--- a/models/pom.xml
+++ b/models/pom.xml
@@ -13,7 +13,8 @@
     <name>models</name>
 
     <properties>
-        <java.version>19</java.version>
+        <maven.compiler.source>19</maven.compiler.source>
+        <maven.compiler.target>19</maven.compiler.target>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/models/src/main/java/org/callimard/makemeacube/models/ModelsConfiguration.java
+++ b/models/src/main/java/org/callimard/makemeacube/models/ModelsConfiguration.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @AutoConfigurationPackage
 @ComponentScan("org.callimard.makemeacube.models")
 @EnableJpaRepositories(enableDefaultTransactions = false)
-public class EntitiesConfiguration {
+public class ModelsConfiguration {
 }

--- a/models/src/main/java/org/callimard/makemeacube/models/dto/UserDTO.java
+++ b/models/src/main/java/org/callimard/makemeacube/models/dto/UserDTO.java
@@ -1,6 +1,6 @@
 package org.callimard.makemeacube.models.dto;
 
-import org.callimard.makemeacube.common.RegistrationProvider;
+import org.callimard.makemeacube.models.sql.RegistrationProvider;
 import org.callimard.makemeacube.models.sql.User;
 
 import java.util.List;

--- a/models/src/main/java/org/callimard/makemeacube/models/sql/RegistrationProvider.java
+++ b/models/src/main/java/org/callimard/makemeacube/models/sql/RegistrationProvider.java
@@ -1,4 +1,4 @@
-package org.callimard.makemeacube.common;
+package org.callimard.makemeacube.models.sql;
 
 public enum RegistrationProvider {
     LOCAL, FACEBOOK, GOOGLE, APPLE

--- a/models/src/main/java/org/callimard/makemeacube/models/sql/User.java
+++ b/models/src/main/java/org/callimard/makemeacube/models/sql/User.java
@@ -3,7 +3,6 @@ package org.callimard.makemeacube.models.sql;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import lombok.*;
-import org.callimard.makemeacube.common.RegistrationProvider;
 import org.callimard.makemeacube.models.dto.DTOSerializable;
 import org.callimard.makemeacube.models.dto.UserDTO;
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
         <module>discovery-service</module>
         <module>proxy-service</module>
         <module>common</module>
+        <module>security</module>
     </modules>
 
     <parent>
@@ -55,6 +56,12 @@
             <dependency>
                 <groupId>org.callimard.makemeacube</groupId>
                 <artifactId>common</artifactId>
+                <version>dev-SNAPSHOT</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.callimard.makemeacube</groupId>
+                <artifactId>security</artifactId>
                 <version>dev-SNAPSHOT</version>
             </dependency>
 

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -7,10 +7,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>jwt</artifactId>
+    <artifactId>security</artifactId>
     <packaging>jar</packaging>
 
-    <name>jwt</name>
+    <name>security</name>
+
     <properties>
         <maven.compiler.source>19</maven.compiler.source>
         <maven.compiler.target>19</maven.compiler.target>
@@ -27,35 +28,13 @@
             <artifactId>models</artifactId>
         </dependency>
 
-        <!-- JWT Auth0 -->
-
         <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>java-jwt</artifactId>
+            <groupId>org.callimard.makemeacube</groupId>
+            <artifactId>jwt</artifactId>
+            <version>dev-SNAPSHOT</version>
         </dependency>
 
         <!-- Spring -->
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -70,7 +49,7 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Google guava -->
+        <!-- Google Guava -->
 
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/security/src/main/java/org/callimard/makemeacube/security/SecurityConfiguration.java
+++ b/security/src/main/java/org/callimard/makemeacube/security/SecurityConfiguration.java
@@ -1,0 +1,11 @@
+package org.callimard.makemeacube.security;
+
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@AutoConfigurationPackage
+@ComponentScan("org.callimard.makemeacube.security")
+public class SecurityConfiguration {
+}

--- a/security/src/main/java/org/callimard/makemeacube/security/aop/NoPersonalUserIdParameterFoundException.java
+++ b/security/src/main/java/org/callimard/makemeacube/security/aop/NoPersonalUserIdParameterFoundException.java
@@ -1,0 +1,10 @@
+package org.callimard.makemeacube.security.aop;
+
+public class NoPersonalUserIdParameterFoundException extends RuntimeException {
+
+    // Constructors.
+
+    public NoPersonalUserIdParameterFoundException() {
+        super();
+    }
+}

--- a/security/src/main/java/org/callimard/makemeacube/security/aop/PersonalAuthorisation.java
+++ b/security/src/main/java/org/callimard/makemeacube/security/aop/PersonalAuthorisation.java
@@ -1,0 +1,16 @@
+package org.callimard.makemeacube.security.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PersonalAuthorisation {
+
+    /**
+     * @return the parameter name which is the user id
+     */
+    String userIdParameterName() default "userId";
+}

--- a/security/src/main/java/org/callimard/makemeacube/security/aop/SecurityAspect.java
+++ b/security/src/main/java/org/callimard/makemeacube/security/aop/SecurityAspect.java
@@ -1,0 +1,68 @@
+package org.callimard.makemeacube.security.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.callimard.makemeacube.jwt.JwtAccount;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Aspect which propose Advice for manage authorisation. All join point suppose that the authentication is a Jwt authentication with a principal which
+ * a {@link JwtAccount}.
+ */
+@Slf4j
+@Component
+@Aspect
+@Order(15)
+public class SecurityAspect {
+
+    // Methods.
+
+    @Before("@annotation(org.callimard.makemeacube.security.aop.PersonalAuthorisation)")
+    public void personalAccessAuthorisation(JoinPoint joinPoint) {
+        log.debug("In personalAccessAuthorisation");
+
+        var jwtAccount = getJwtAccount();
+
+        MethodSignature mSignature = (MethodSignature) joinPoint.getSignature();
+        Method m = mSignature.getMethod();
+
+        PersonalAuthorisation personalAuthorisation = m.getAnnotation(PersonalAuthorisation.class);
+        log.debug("In personalAccessAuthorisation, jwt account = {}, userIdParameterName = {}", jwtAccount, personalAuthorisation.userIdParameterName());
+        int parameterIndex = getUserIdParameterIndex(mSignature, personalAuthorisation.userIdParameterName());
+
+        if (!Objects.equals(jwtAccount.getId(), joinPoint.getArgs()[parameterIndex])) {
+            log.debug("Unauthorized -> the user id param equals = {} and jwt account id = {}", joinPoint.getArgs()[parameterIndex],
+                      jwtAccount.getId());
+            throw new UnauthorizedAccessException();
+        }
+    }
+
+    private static int getUserIdParameterIndex(MethodSignature mSignature, String userIdParamName) {
+        int parameterIndex = -1;
+        int counter = 0;
+        for (String paramName : mSignature.getParameterNames()) {
+            if (paramName.equals(userIdParamName)) {
+                parameterIndex = counter;
+                break;
+            }
+            counter++;
+        }
+
+        if (parameterIndex == -1) {
+            throw new NoPersonalUserIdParameterFoundException();
+        }
+        return parameterIndex;
+    }
+
+    private JwtAccount getJwtAccount() {
+        return (JwtAccount) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/security/src/main/java/org/callimard/makemeacube/security/aop/UnauthorizedAccessException.java
+++ b/security/src/main/java/org/callimard/makemeacube/security/aop/UnauthorizedAccessException.java
@@ -1,0 +1,14 @@
+package org.callimard.makemeacube.security.aop;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedAccessException extends RuntimeException {
+
+    // Constructors.
+
+    public UnauthorizedAccessException() {
+        super();
+    }
+}

--- a/user-management/pom.xml
+++ b/user-management/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.callimard.makemeacube</groupId>
+            <artifactId>security</artifactId>
+        </dependency>
+
         <!-- MySQL -->
 
         <dependency>
@@ -95,10 +100,10 @@
         </dependency>
 
         <!-- Google Guava -->
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
         </dependency>
     </dependencies>
 </project>

--- a/user-management/src/main/java/org/callimard/makemeacube/user_management/UserManagementConfiguration.java
+++ b/user-management/src/main/java/org/callimard/makemeacube/user_management/UserManagementConfiguration.java
@@ -1,14 +1,14 @@
 package org.callimard.makemeacube.user_management;
 
 import lombok.RequiredArgsConstructor;
-import org.callimard.makemeacube.common.api.ApiV1;
 import org.callimard.makemeacube.common.CommonConfiguration;
-import org.callimard.makemeacube.models.EntitiesConfiguration;
+import org.callimard.makemeacube.common.api.ApiV1;
 import org.callimard.makemeacube.jwt.JwtAuthenticationProvider;
 import org.callimard.makemeacube.jwt.JwtCompanyAuthenticationDSL;
 import org.callimard.makemeacube.jwt.JwtConfiguration;
+import org.callimard.makemeacube.models.ModelsConfiguration;
+import org.callimard.makemeacube.security.SecurityConfiguration;
 import org.callimard.makemeacube.user_management.authentication.BasicAuthenticationProvider;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,12 +22,11 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 @Configuration
 @EnableConfigurationProperties
-@ConfigurationProperties(prefix = "security")
 @EnableGlobalMethodSecurity(
         prePostEnabled = true,
         securedEnabled = true,
         jsr250Enabled = true)
-@Import({JwtConfiguration.class, EntitiesConfiguration.class, CommonConfiguration.class})
+@Import({JwtConfiguration.class, ModelsConfiguration.class, CommonConfiguration.class, SecurityConfiguration.class})
 public class UserManagementConfiguration {
 
     // Variables.

--- a/user-management/src/main/java/org/callimard/makemeacube/user_management/registration/UserRegistrationController.java
+++ b/user-management/src/main/java/org/callimard/makemeacube/user_management/registration/UserRegistrationController.java
@@ -1,9 +1,13 @@
 package org.callimard.makemeacube.user_management.registration;
 
 import lombok.RequiredArgsConstructor;
-import org.callimard.makemeacube.common.RegistrationProvider;
+import org.callimard.makemeacube.models.sql.RegistrationProvider;
 import org.callimard.makemeacube.common.api.ApiV1;
+import org.callimard.makemeacube.jwt.JwtAccount;
+import org.callimard.makemeacube.jwt.aop.RequiresJwtAuthentication;
 import org.callimard.makemeacube.models.dto.UserDTO;
+import org.callimard.makemeacube.security.aop.PersonalAuthorisation;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -27,14 +31,16 @@ public class UserRegistrationController {
         return userRegistrationService.makerUserRegistration(makerUserRegistrationDTO, RegistrationProvider.LOCAL).toDTO();
     }
 
-    // TODO add real authorization
+    @RequiresJwtAuthentication
+    @PersonalAuthorisation
     @PutMapping("/{userId}")
     public UserDTO updateUserInformation(@PathVariable(name = "userId") Integer userId,
                                          @RequestBody UserRegistrationService.UserUpdatedInformation userUpdatedInformation) {
         return userRegistrationService.updateUserInformation(userId, userUpdatedInformation).toDTO();
     }
 
-    // TODO add real authorization
+    @RequiresJwtAuthentication
+    @PersonalAuthorisation
     @PutMapping("/{userId}/addresses")
     public UserDTO updateUserAddresses(@PathVariable(name = "userId") Integer userId,
                                        @RequestBody UserRegistrationService.AddressInformationDTO addressInformationDTO) {

--- a/user-management/src/main/java/org/callimard/makemeacube/user_management/registration/UserRegistrationService.java
+++ b/user-management/src/main/java/org/callimard/makemeacube/user_management/registration/UserRegistrationService.java
@@ -1,6 +1,6 @@
 package org.callimard.makemeacube.user_management.registration;
 
-import org.callimard.makemeacube.common.RegistrationProvider;
+import org.callimard.makemeacube.models.sql.RegistrationProvider;
 import org.callimard.makemeacube.common.validation.ValidEmail;
 import org.callimard.makemeacube.common.validation.ValidPassword;
 import org.callimard.makemeacube.common.validation.ValidPhone;

--- a/user-management/src/main/java/org/callimard/makemeacube/user_management/registration/UserRegistrationServiceImpl.java
+++ b/user-management/src/main/java/org/callimard/makemeacube/user_management/registration/UserRegistrationServiceImpl.java
@@ -2,7 +2,7 @@ package org.callimard.makemeacube.user_management.registration;
 
 import com.google.common.collect.Lists;
 import lombok.RequiredArgsConstructor;
-import org.callimard.makemeacube.common.RegistrationProvider;
+import org.callimard.makemeacube.models.sql.RegistrationProvider;
 import org.callimard.makemeacube.models.aop.EntitySearchWithIdAspect;
 import org.callimard.makemeacube.models.aop.SearchUsers;
 import org.callimard.makemeacube.models.aop.UserId;


### PR DESCRIPTION
Create a Security module. In this module is defined an Advice which control the personal access.

If an end point as a @PersonalAuthorisation annotation, therefore it must have a parameter which is the id of the user and this end point can be access only if the authenticated user (with a Jwt and a JwtAccount) have the same id as the specified user id in parameter.

In addition to this, create a @RequiresJwtAuthentication annotation which verify that the request is called with a Jwt authentication (JwtAccount)

Signed-off-by: Callimard <guil.rako@hotmail.fr>