### PR TITLE
#27 Pseudo and Mail are stored in lower case

### DIFF
--- a/user-management/src/main/java/org/callimard/makemeacube/user_management/authentication/BasicAuthenticationProvider.java
+++ b/user-management/src/main/java/org/callimard/makemeacube/user_management/authentication/BasicAuthenticationProvider.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import java.util.Locale;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -41,12 +43,10 @@ public class BasicAuthenticationProvider implements AuthenticationProvider {
     }
 
     private User searchUser(String username) {
-        // Search by mail
-        var user = userRepository.findByMail(username);
+        var user = userRepository.findByMail(username.toLowerCase(Locale.FRENCH));
 
         if (user.isEmpty()) {
-            // Search by pseudo
-            user = userRepository.findByPseudo(username);
+            user = userRepository.findByPseudo(username.toLowerCase(Locale.FRENCH));
         }
 
         // Unknown mail or pseudo

--- a/user-management/src/main/java/org/callimard/makemeacube/user_management/management/UserManagementServiceImpl.java
+++ b/user-management/src/main/java/org/callimard/makemeacube/user_management/management/UserManagementServiceImpl.java
@@ -14,6 +14,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 
 @RequiredArgsConstructor
 @Validated
@@ -39,7 +40,7 @@ public class UserManagementServiceImpl implements UserManagementService {
     @Override
     public User basicUserRegistration(@NotNull @Valid BasicUserRegistrationDTO userInfo, @NotNull RegistrationProvider provider) {
         // TODO Manage the email verification
-        var user = new User(userInfo.mail(), userInfo.pseudo(),
+        var user = new User(userInfo.mail().toLowerCase(Locale.FRENCH), userInfo.pseudo().toLowerCase(Locale.FRENCH),
                             passwordEncoder.encode(userInfo.password()), provider, Instant.now());
         return userRepository.save(user);
     }
@@ -60,8 +61,8 @@ public class UserManagementServiceImpl implements UserManagementService {
 
     private User generateMaker(MakerUserRegistrationDTO makerInfo) {
         return new User(-1,
-                        makerInfo.mail(),
-                        makerInfo.pseudo(),
+                        makerInfo.mail().toLowerCase(Locale.FRENCH),
+                        makerInfo.pseudo().toLowerCase(Locale.FRENCH),
                         passwordEncoder.encode(makerInfo.password()),
                         makerInfo.firstName(),
                         makerInfo.lastName(),


### PR DESCRIPTION
Pseudo and Mail are stored in lower case.
In addition to this, when we check email or
pseudo, we check it in lower case.

Signed-off-by: Callimard <guil.rako@hotmail.fr>